### PR TITLE
docs: fixed typographical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you can't see the video, you can watch it [here](https://www.youtube.com/watc
 
 -   **Step 2**: Update and WebSocket server details in `src/Config.cpp`
 
-    -   Find your WiFi ip adress (websocket_server_host) by command `ipconfig` (under `Default Gateway`) in Windows or `ifconfig` (under `inet xxx.x.x.x netmask 0xff000000`) in Linux/MacOS, or you can also follow the instructions [here](https://nordvpn.com/blog/find-router-ip-address/)
+    -   Find your WiFi IP address (websocket_server_host) by command `ipconfig` (under `Default Gateway`) in Windows or `ifconfig` (under `inet xxx.x.x.x netmask 0xff000000`) in Linux/MacOS, or you can also follow the instructions [here](https://nordvpn.com/blog/find-router-ip-address/)
 
         ```cpp
         const char *websocket_server = "<your-server-host-ip>"; // Wifi settings -> Your Wifi I.P.


### PR DESCRIPTION
adress -> address
Related to PR #2, it back to 'adress' again now.
Previous commit is [not found](https://github.com/StarmoonAI/Starmoon/commit/80b4d5872eac53c977414540ef7945eb7ba7d1a1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5). 